### PR TITLE
Fixed deprecation warning

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.3' ]
         dependency-version: [ prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.3' ]
         dependency-version: [ prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.3' ]
         dependency-version: [ prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -113,20 +113,16 @@ jobs:
         run: |
           # We need a Drupal project to run drupal-check (cf. https://github.com/mglaman/drupal-check#usage)
           # Install Drupal
-          composer --no-interaction create-project drupal/recommended-project:^9 drupal
+          composer --no-interaction create-project drupal/recommended-project:^10 --stability=dev drupal
           # Copy our module source code into the Drupal module folder.
           mkdir -p drupal/web/modules/contrib/beskedfordeler
           cp -r beskedfordeler.* composer.json src drupal/web/modules/contrib/beskedfordeler
-
-          composer --working-dir=drupal --no-interaction config minimum-stability dev
-
-          # Allow plugins
-          composer --working-dir=drupal config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-
+          
           # Add our module as a composer repository.
           composer --working-dir=drupal --no-interaction config --append repositories.itk-dev/beskedfordeler-drupal path web/modules/contrib/beskedfordeler
+          
           # Restore Drupal composer repository.
-          # composer --working-dir=drupal --no-interaction config --append repositories.drupal composer https://packages.drupal.org/8
+          composer --no-interaction --working-dir=drupal config repositories.drupal composer https://packages.drupal.org/8
 
           # Require our module.
           composer --working-dir=drupal --no-interaction require 'itk-dev/beskedfordeler-drupal:*'
@@ -161,7 +157,7 @@ jobs:
       - name: Yarn install
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '20'
       - run: yarn install
       - name: coding-standards-check
         run: yarn coding-standards-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.1]
+
+### Changed
+
+- [PR-7](https://github.com/itk-dev/beskedfordeler-drupal/pull/7)
+  Handled `RequestStack` deprecation
+
 ## [1.2.0]
 
 ### Updated
@@ -34,7 +41,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added Beskedfordeler module.
 
-[Unreleased]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.2.0...HEAD
+[Unreleased]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.2.1...HEAD
+[1.2.1]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.0.0...1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0]
+
+### Updated
+
+- [PR-6](https://github.com/itk-dev/beskedfordeler-drupal/pull/6)
+  Drupal 10 compatibility
+
 ## [1.1.1]
 
 ### Changed
@@ -27,7 +34,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added Beskedfordeler module.
 
-[Unreleased]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.1.1...HEAD
+[Unreleased]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/itk-dev/beskedfordeler-drupal/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/itk-dev/beskedfordeler-drupal/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Beskedfordeler for Drupal.
 ## Installation
 
 ```sh
-composer require itk-dev/beskedfordeler
+composer require itk-dev/beskedfordeler-drupal
 drush pm:enable beskedfordeler
 ```
 
@@ -147,17 +147,17 @@ Actions](https://github.com/features/actions) when a pull request is made (cf.
 Check coding standards:
 
 ```sh
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.1-fpm:latest composer install
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.1-fpm:latest composer coding-standards-check
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.3-fpm:latest composer install
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.3-fpm:latest composer coding-standards-check
 
-docker run --rm --interactive --tty --volume ${PWD}:/app node:18 yarn --cwd /app install
-docker run --rm --interactive --tty --volume ${PWD}:/app node:18 yarn --cwd /app coding-standards-check
+docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app install
+docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app coding-standards-check
 ```
 
 Apply coding standards:
 
 ```shell
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.1-fpm:latest composer coding-standards-apply
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.3-fpm:latest composer coding-standards-apply
 
-docker run --rm --interactive --tty --volume ${PWD}:/app node:18 yarn --cwd /app coding-standards-apply
+docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app coding-standards-apply
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "drupal/coder": "^8.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "mglaman/drupal-check": "^1.4",
+        "mglaman/phpstan-drupal": "~1.2.0",
         "phpunit/phpunit": "^9.5"
     },
     "scripts": {

--- a/modules/beskedfordeler_database/src/Commands/MessageCommands.php
+++ b/modules/beskedfordeler_database/src/Commands/MessageCommands.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\beskedfordeler_database\Commands;
 
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\beskedfordeler\Helper\MessageHelper;
 use Drupal\beskedfordeler_database\Helper\Helper;
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -49,9 +49,11 @@ final class MessageCommands extends DrushCommands {
    *
    * @phpstan-param array<string, mixed> $options
    */
-  public function list(array $options = [
-    'type' => NULL,
-  ]): void {
+  public function list(
+    array $options = [
+      'type' => NULL,
+    ],
+  ): void {
     $messages = $this->helper->loadMessages($options['type'], $options['distinct']);
 
     foreach ($messages as $message) {
@@ -80,10 +82,13 @@ final class MessageCommands extends DrushCommands {
    * @command beskedfordeler:message:show
    * @usage beskedfordeler:message:show --help
    */
-  public function show(string $id, array $options = [
-    'decode-data' => FALSE,
-    'data-only' => FALSE,
-  ]): void {
+  public function show(
+    string $id,
+    array $options = [
+      'decode-data' => FALSE,
+      'data-only' => FALSE,
+    ],
+  ): void {
     $message = $this->helper->loadMessage($id);
 
     if (NULL === $message) {

--- a/modules/beskedfordeler_database/src/Controller/Controller.php
+++ b/modules/beskedfordeler_database/src/Controller/Controller.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\beskedfordeler_database\Controller;
 
-use Drupal\beskedfordeler\Helper\MessageHelper;
-use Drupal\beskedfordeler_database\Helper\Helper;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\beskedfordeler\Helper\MessageHelper;
+use Drupal\beskedfordeler_database\Helper\Helper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 

--- a/modules/beskedfordeler_database/src/Helper/Helper.php
+++ b/modules/beskedfordeler_database/src/Helper/Helper.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\beskedfordeler_database\Helper;
 
+use Drupal\Core\Database\Connection;
 use Drupal\beskedfordeler\Event\AbstractBeskedModtagEvent;
 use Drupal\beskedfordeler\Exception\InvalidMessageException;
 use Drupal\beskedfordeler_database\Model\Message;
-use Drupal\Core\Database\Connection;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 
@@ -68,7 +68,7 @@ final class Helper {
    * @return array|Message[]
    *   The messages.
    */
-  public function loadMessages(string $type = NULL): array {
+  public function loadMessages(?string $type = NULL): array {
     $query = $this->database
       ->select(self::TABLE_NAME, 'm')
       ->fields('m');

--- a/modules/beskedfordeler_forward/src/EventSubscriber/ForwardEventSubscriber.php
+++ b/modules/beskedfordeler_forward/src/EventSubscriber/ForwardEventSubscriber.php
@@ -23,7 +23,7 @@ class ForwardEventSubscriber extends AbstractBeskedfordelerEventSubscriber {
   /**
    * The request stack.
    *
-   * @var \Drupal\Core\Http\RequestStack
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   private RequestStack $requestStack;
 

--- a/modules/beskedfordeler_forward/src/EventSubscriber/ForwardEventSubscriber.php
+++ b/modules/beskedfordeler_forward/src/EventSubscriber/ForwardEventSubscriber.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\beskedfordeler_forward\EventSubscriber;
 
+use Drupal\Core\Site\Settings;
 use Drupal\beskedfordeler\Event\PostStatusBeskedModtagEvent;
 use Drupal\beskedfordeler\EventSubscriber\AbstractBeskedfordelerEventSubscriber;
-use Drupal\Core\Http\RequestStack;
-use Drupal\Core\Site\Settings;
 use GuzzleHttp\ClientInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Event subscriber for forwarding Beskedfordeler messages.

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\beskedfordeler\Controller;
 
-use Drupal\beskedfordeler\Helper\MessageHelper;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\beskedfordeler\Helper\MessageHelper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -91,7 +91,7 @@ class Controller extends ControllerBase {
    *
    * @see self::buildResponseDocument()
    */
-  private function buildResponse(int $statusCode, string $errorMessage = NULL): Response {
+  private function buildResponse(int $statusCode, ?string $errorMessage = NULL): Response {
     $document = $this->buildResponseDocument($statusCode, $errorMessage);
 
     $status = Response::HTTP_OK;
@@ -112,7 +112,7 @@ class Controller extends ControllerBase {
    * @return \DOMDocument
    *   The Outputdokument.
    */
-  private function buildResponseDocument(int $statusCode, string $errorMessage = NULL): \DOMDocument {
+  private function buildResponseDocument(int $statusCode, ?string $errorMessage = NULL): \DOMDocument {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns2:ModtagBeskedOutput xmlns="urn:oio:sagdok:3.0.0" xmlns:ns2="urn:oio:sts:1.0.0">

--- a/src/Event/AbstractBeskedModtagEvent.php
+++ b/src/Event/AbstractBeskedModtagEvent.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\beskedfordeler\Event;
 
-use Drupal\beskedfordeler\Exception\InvalidEventException;
 use Drupal\Component\EventDispatcher\Event;
+use Drupal\beskedfordeler\Exception\InvalidEventException;
 
 /**
  * Abstract event for BeskedModtag.


### PR DESCRIPTION
In Drupal 10 `Drupal\Core\Http\RequestStack` is deprecated, cf. https://www.drupal.org/node/3265357.

See https://github.com/itk-dev/os2forms_payment/pull/4 for note about `mglaman/phpstan-drupal`.